### PR TITLE
Actually create queues / topics during queue / topic create. Correct …

### DIFF
--- a/src/AzureStorageContext.php
+++ b/src/AzureStorageContext.php
@@ -40,17 +40,23 @@ class AzureStorageContext implements Context
 
     public function createTopic(string $topicName): Topic
     {
+        $this->client->createQueue($topicName);
+
         return new AzureStorageDestination($topicName);
     }
 
     public function createQueue(string $queueName): Queue
     {
+        $this->client->createQueue($queueName);
+
         return new AzureStorageDestination($queueName);
     }
 
 
     /**
      * @param AzureStorageDestination $queue
+     *
+     * @throws InvalidDestinationException Thrown, when destination is incompatible with the driver.
      */
     public function deleteQueue(Queue $queue): void
     {
@@ -61,6 +67,8 @@ class AzureStorageContext implements Context
 
     /**
      * @param AzureStorageDestination $topic
+     *
+     * @throws InvalidDestinationException Thrown, when destination is incompatible with the driver.
      */
     public function deleteTopic(Topic $topic): void
     {
@@ -84,8 +92,10 @@ class AzureStorageContext implements Context
 
     /**
      * @param AzureStorageDestination $destination
+     *
      * @return Consumer
-     * @throws InvalidDestinationException
+     *
+     * @throws InvalidDestinationException Thrown, when destination is incompatible with the driver.
      */
     public function createConsumer(Destination $destination): Consumer
     {

--- a/src/Driver/AzureStorageDriver.php
+++ b/src/Driver/AzureStorageDriver.php
@@ -5,8 +5,6 @@ namespace Enqueue\AzureStorage\Driver;
 use Enqueue\AzureStorage\AzureStorageContext;
 use Enqueue\AzureStorage\AzureStorageDestination;
 use Enqueue\Client\Driver\GenericDriver;
-use Psr\Log\LoggerInterface;
-use Psr\Log\NullLogger;
 
 /**
  * @method AzureStorageContext getContext
@@ -17,5 +15,22 @@ class AzureStorageDriver extends GenericDriver
     public function __construct(AzureStorageContext $context, ...$args)
     {
         parent::__construct($context, ...$args);
+    }
+
+    /**
+     * Create transport queue name.
+     *
+     * This driver replaces some queue name characters, which are not valid in Azure Storage queues.
+     *
+     * @param string $name
+     * @param bool $prefix
+     *
+     * @return string
+     */
+    protected function createTransportQueueName(string $name, bool $prefix): string
+    {
+        $name = parent::createTransportQueueName($name, $prefix);
+
+        return str_replace(['.', '_'], ['-dot-', '--'], $name);
     }
 }

--- a/src/Driver/AzureStorageDriver.php
+++ b/src/Driver/AzureStorageDriver.php
@@ -31,6 +31,6 @@ class AzureStorageDriver extends GenericDriver
     {
         $name = parent::createTransportQueueName($name, $prefix);
 
-        return str_replace(['.', '_'], ['-dot-', '--'], $name);
+        return str_replace(['.', '_'], ['-dot-', '-'], $name);
     }
 }

--- a/tests/AzureStorageContextTest.php
+++ b/tests/AzureStorageContextTest.php
@@ -125,9 +125,16 @@ class AzureStorageContextTest extends \PHPUnit\Framework\TestCase
 
     public function testShouldAllowDeleteQueue()
     {
-        $context = new AzureStorageContext($this->createQueueRestProxyMock());
+        $proxyMock = $this->createQueueRestProxyMock();
+        $context = new AzureStorageContext($proxyMock);
 
         $queue = $context->createQueue('aQueueName');
+
+        // Check, that delete queue command actually is invoked on client.
+        $proxyMock
+            ->expects($this->once())
+            ->method('deleteQueue')
+            ->with($queue);
 
         $context->deleteQueue($queue);
     }
@@ -142,9 +149,16 @@ class AzureStorageContextTest extends \PHPUnit\Framework\TestCase
 
     public function testShouldAllowDeleteTopic()
     {
-        $context = new AzureStorageContext($this->createQueueRestProxyMock());
+        $proxyMock = $this->createQueueRestProxyMock();
+        $context = new AzureStorageContext($proxyMock);
 
         $topic = $context->createTopic('aTopicName');
+
+        // Check, that delete queue command actually is invoked on client.
+        $proxyMock
+            ->expects($this->once())
+            ->method('deleteQueue')
+            ->with($topic);
 
         $context->deleteQueue($topic);
     }

--- a/tests/Driver/AzureStorageDriverTest.php
+++ b/tests/Driver/AzureStorageDriverTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Enqueue\AzureStorage\Tests\Driver;
+
+use Enqueue\AzureStorage\AzureStorageContext;
+use Enqueue\AzureStorage\Driver\AzureStorageDriver;
+use Enqueue\Client\Config;
+use Enqueue\Client\RouteCollection;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class AzureStorageDriverTest.
+ */
+class AzureStorageDriverTest extends TestCase
+{
+    public function testCreateTransportQueueName(): void
+    {
+        $context = $this->createContextMock();
+        $driver =
+            new AzureStorageDriver(
+                $context,
+                new Config('enqueue', '.', 'app', 'topic', 'queue', 'default', 'processor', [], []),
+                new RouteCollection([])
+            );
+        $context
+            ->expects($this->once())
+            ->method('createQueue')
+            ->with('enqueue-dot-app-dot-test-queue');
+
+        $driver->createQueue('test_queue');
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|AzureStorageContext
+     */
+    private function createContextMock()
+    {
+        return $this->createMock(AzureStorageContext::class);
+    }
+}


### PR DESCRIPTION
…queue/topic naming.

This PR adds possibility to actually create queues and topics in Azure, if necessary.

It also gives some formatting to queue / topic names, replacing some commonly used in enqueue - but invalid in Azure Storage - characters.