### PR TITLE
Update dependency versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,13 @@
         "php": "^7.1.3",
         "queue-interop/queue-interop": "^0.7|^0.8",
         "microsoft/azure-storage-queue": "^1.1",
-        "enqueue/enqueue": "^0.9.0@dev"
+        "enqueue/enqueue": "^0.9|^0.10"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.4.0",
-        "enqueue/test": "0.9.x-dev",
-        "enqueue/null": "0.9.x-dev",
-        "queue-interop/queue-spec": "0.6.x-dev"
+        "phpunit/phpunit": "^5.5",
+        "enqueue/test": "0.9.x-dev|0.10.x-dev",
+        "enqueue/null": "0.9.x-dev|0.10.x-dev",
+        "queue-interop/queue-spec": "^0.6@dev"
     },
     "support": {
         "email": "github@assoconnect.com",


### PR DESCRIPTION
This updates the dependency versions. The main scope was enabling enqueue 0.10.

 Changes are as follows:
* enqueue/enqueue can be 0.9 or 0.10
* enqueue/test can be 0.9.x-dev or 0.10.x-dev

I also raised the version of phpunit.